### PR TITLE
No errors and default yml

### DIFF
--- a/src/bin
+++ b/src/bin
@@ -13,7 +13,11 @@ function showHelp() {
   process.exit(0);
 }
 
-const cmd = process.argv[2];
+let cmd = process.argv[2];
+
+if (!cmd && fs.existsSync('.gitlab-ci.yml')) {
+  cmd = '.gitlab-ci.yml';
+}
 
 if (cmd === '-h' || cmd === '--help') {
   showHelp();

--- a/src/bin
+++ b/src/bin
@@ -2,9 +2,7 @@
 const chalk = require('chalk');
 const gitlabCiValidate = require('../src/index');
 
-const cmd = process.argv[2];
-
-if (!cmd || cmd === '-h' || cmd === '--help') {
+function showHelp() {
   console.log(`
   Usage
     $ gitlab-ci-validate <file-path>
@@ -12,6 +10,12 @@ if (!cmd || cmd === '-h' || cmd === '--help') {
     $ gitlab-ci-validate -h --help
   `);
   process.exit(0);
+}
+
+const cmd = process.argv[2];
+
+if (!cmd || cmd === '-h' || cmd === '--help') {
+  showHelp();
 }
 
 gitlabCiValidate(cmd).then((data) => {

--- a/src/bin
+++ b/src/bin
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+const fs = require('fs');
 const chalk = require('chalk');
 const gitlabCiValidate = require('../src/index');
 
@@ -14,7 +15,13 @@ function showHelp() {
 
 const cmd = process.argv[2];
 
-if (!cmd || cmd === '-h' || cmd === '--help') {
+if (cmd === '-h' || cmd === '--help') {
+  showHelp();
+}
+
+if (!fs.existsSync(cmd)) {
+  console.log(chalk.red(`
+  ERROR: ${cmd} does not exists!`));
   showHelp();
 }
 


### PR DESCRIPTION
## What does this pull request do?

> First i would like to thx You for this nice tool, it will definitely finding place in my toolkit :+1: 

Made some tweaks to make it even better:

 * If no filepath given and `.gitlab-ci.yml` is present then this will be used as default value 
    - _While in gitlab its possible to change ci config filepath, i think never seen anyone actually do it_
 * Added error check, that file given as argument actually exists - before it did give error like this:
```
siims-MacBook-Pro-2:gitlab-ci-validate eritikass$ gitlab-ci-validate no-file-like-this
fs.js:653
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open 'no-file-like-this'
    at Object.fs.openSync (fs.js:653:18)
    at Object.fs.readFileSync (fs.js:554:33)
    at gitlabCiValidate (/Users/eritikass/.config/yarn/global/node_modules/gitlab-ci-validate/src/index.js:5:19)
    at Object.<anonymous> (/Users/eritikass/.config/yarn/global/node_modules/gitlab-ci-validate/src/bin:17:1)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Function.Module.runMain (module.js:665:10)
    at startup (bootstrap_node.js:201:16)
    at bootstrap_node.js:626:3
```
